### PR TITLE
Improve video URL detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A simple Chrome extension that helps you:
 
 - Copy tweet links with `/video/1` for quoting
-- (Soon) Download Twitter/X videos
+- Download Twitter/X videos (MP4) or open a GIF converter
 
 ### ✅ Features
 - Automatically detects tweet URL in the current tab
@@ -13,7 +13,7 @@ A simple Chrome extension that helps you:
 - Lightweight and fast
 
 ### 🚀 Coming Soon
-- Direct video download support
+- Additional download options
 
 ### 🧩 Installation
 1. Clone or download this repo.

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
   "name": "Twitter Video Helper",
   "version": "1.0",
   "description": "Copy tweet link with /video/1 for quoting.",
-  "permissions": ["scripting", "activeTab", "clipboardWrite"],
-  "host_permissions": ["*://twitter.com/*", "*://x.com/*"],
+  "permissions": ["scripting", "activeTab", "clipboardWrite", "downloads"],
+  "host_permissions": ["*://twitter.com/*", "*://x.com/*", "*://*.twimg.com/*"],
   "action": {
     "default_popup": "popup.html",
     "default_icon": "icon.png"

--- a/popup.html
+++ b/popup.html
@@ -61,6 +61,8 @@
 <body>
   <button id="copy-link">Quote Video</button>
   <button id="download">Download Video</button>
+  <button id="download-mp4" style="display:none;">Download MP4</button>
+  <button id="download-gif" style="display:none;">Download GIF</button>
   <div id="toast"></div>
 
   <div class="credit">

--- a/popup.js
+++ b/popup.js
@@ -26,6 +26,84 @@ document.getElementById("copy-link").addEventListener("click", () => {
   });
 });
 
-document.getElementById("download").addEventListener("click", () => {
-  showToast("Download coming soon!");
+const downloadBtn = document.getElementById("download");
+const mp4Btn = document.getElementById("download-mp4");
+const gifBtn = document.getElementById("download-gif");
+
+function getVideoUrl() {
+  // Check meta tags for direct MP4 links first
+  const metaMp4 = document.querySelector(
+    'meta[property="og:video:url"], meta[name="twitter:player:stream"]'
+  );
+  if (metaMp4 && metaMp4.content) {
+    const url = metaMp4.content;
+    if (/\.mp4(\?.*)?$/.test(url)) {
+      return url;
+    }
+  }
+
+  const html = document.documentElement.innerHTML;
+  const mp4Match = html.match(
+    /https:\/\/(?:video|pbs)\.twimg\.com[^"']+\.mp4[^"']*/
+  );
+  if (mp4Match) {
+    return mp4Match[0];
+  }
+  const videoEl = document.querySelector('video');
+  if (videoEl) {
+    const src = videoEl.currentSrc || videoEl.src;
+    if (src && !src.startsWith('blob:')) {
+      return src;
+    }
+    const source = videoEl.querySelector('source');
+    if (source && source.src && !source.src.startsWith('blob:')) {
+      return source.src;
+    }
+  }
+  return null;
+}
+
+function fetchVideoUrl(tabId, callback) {
+  chrome.scripting.executeScript({
+    target: { tabId },
+    func: getVideoUrl,
+  }, (results) => {
+    if (chrome.runtime.lastError || !results || !results.length) {
+      callback(null);
+    } else {
+      callback(results[0].result);
+    }
+  });
+}
+
+downloadBtn.addEventListener("click", () => {
+  mp4Btn.style.display = "block";
+  gifBtn.style.display = "block";
+});
+
+mp4Btn.addEventListener("click", () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+    fetchVideoUrl(tab.id, (videoUrl) => {
+      if (videoUrl) {
+        chrome.downloads.download({ url: videoUrl, filename: 'twitter-video.mp4' });
+        showToast('Downloading MP4...');
+      } else {
+        showToast('Video URL not found.');
+      }
+    });
+  });
+});
+
+gifBtn.addEventListener("click", () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+    fetchVideoUrl(tab.id, (videoUrl) => {
+      if (videoUrl) {
+        const gifUrl = 'https://ezgif.com/video-to-gif?url=' + encodeURIComponent(videoUrl);
+        chrome.tabs.create({ url: gifUrl });
+        showToast('Opening GIF converter...');
+      } else {
+        showToast('Video URL not found.');
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- extend detection logic in `popup.js` to read `og:video:url` or `twitter:player:stream` meta tags
- fall back to previous DOM search to grab the MP4 link

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6884e4aedd60832887679b1b17909298